### PR TITLE
Add version constraints in .cabal file

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -49,20 +49,20 @@ default-extensions:
   - ViewPatterns
 
 dependencies:
-  - aeson
+  - aeson == 1.5.6.0
   - base < 5.0
-  - bytestring
-  - Cabal
-  - cabal-install-parsers
-  - containers
-  - directory
-  - filepath
-  - megaparsec
-  - monad-logger
-  - mtl
-  - process
-  - text
-  - yaml
+  - bytestring == 0.10.12.0
+  - Cabal == 3.2.1.0
+  - cabal-install-parsers == 0.3.0.1
+  - containers == 0.6.2.1
+  - directory == 1.3.6.0
+  - filepath == 1.4.2.1
+  - megaparsec == 9.0.1
+  - monad-logger == 0.3.36
+  - mtl == 2.2.2
+  - process == 1.6.9.0
+  - text == 1.2.4.1
+  - yaml == 0.11.5.0
 
 extra-source-files:
   - stack.yaml
@@ -80,9 +80,9 @@ tests:
     source-dirs:
       - test
     dependencies:
-      - file-embed
-      - file-path-th
-      - hspec
+      - file-embed == 0.0.13.0
+      - file-path-th == 0.1.0.0
+      - hspec == 2.7.8
 
       - prune-juice
 
@@ -92,6 +92,6 @@ executables:
     source-dirs:
       - app
     dependencies:
-      - optparse-applicative
+      - optparse-applicative == 0.15.1.0
 
       - prune-juice

--- a/prune-juice.cabal
+++ b/prune-juice.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 99725ce5eb48860666f10031a3c191aa02df757be5624aa98f05bd47fbabf62f
+-- hash: 4bd517ab58fd6a4ec5a51e3bb1480c363da0c509ad1737125f0278b4b476dfae
 
 name:           prune-juice
 version:        0.6
@@ -73,20 +73,20 @@ library
       ViewPatterns
   ghc-options: -Wall -fwarn-tabs -fwarn-redundant-constraints -Wincomplete-uni-patterns -eventlog
   build-depends:
-      Cabal
-    , aeson
+      Cabal ==3.2.1.0
+    , aeson ==1.5.6.0
     , base <5.0
-    , bytestring
-    , cabal-install-parsers
-    , containers
-    , directory
-    , filepath
-    , megaparsec
-    , monad-logger
-    , mtl
-    , process
-    , text
-    , yaml
+    , bytestring ==0.10.12.0
+    , cabal-install-parsers ==0.3.0.1
+    , containers ==0.6.2.1
+    , directory ==1.3.6.0
+    , filepath ==1.4.2.1
+    , megaparsec ==9.0.1
+    , monad-logger ==0.3.36
+    , mtl ==2.2.2
+    , process ==1.6.9.0
+    , text ==1.2.4.1
+    , yaml ==0.11.5.0
   default-language: Haskell2010
 
 executable prune-juice
@@ -128,22 +128,22 @@ executable prune-juice
       ViewPatterns
   ghc-options: -Wall -fwarn-tabs -fwarn-redundant-constraints -Wincomplete-uni-patterns -eventlog
   build-depends:
-      Cabal
-    , aeson
+      Cabal ==3.2.1.0
+    , aeson ==1.5.6.0
     , base <5.0
-    , bytestring
-    , cabal-install-parsers
-    , containers
-    , directory
-    , filepath
-    , megaparsec
-    , monad-logger
-    , mtl
-    , optparse-applicative
-    , process
+    , bytestring ==0.10.12.0
+    , cabal-install-parsers ==0.3.0.1
+    , containers ==0.6.2.1
+    , directory ==1.3.6.0
+    , filepath ==1.4.2.1
+    , megaparsec ==9.0.1
+    , monad-logger ==0.3.36
+    , mtl ==2.2.2
+    , optparse-applicative ==0.15.1.0
+    , process ==1.6.9.0
     , prune-juice
-    , text
-    , yaml
+    , text ==1.2.4.1
+    , yaml ==0.11.5.0
   default-language: Haskell2010
 
 test-suite test
@@ -189,22 +189,22 @@ test-suite test
       ViewPatterns
   ghc-options: -Wall -fwarn-tabs -fwarn-redundant-constraints -Wincomplete-uni-patterns -eventlog
   build-depends:
-      Cabal
-    , aeson
+      Cabal ==3.2.1.0
+    , aeson ==1.5.6.0
     , base <5.0
-    , bytestring
-    , cabal-install-parsers
-    , containers
-    , directory
-    , file-embed
-    , file-path-th
-    , filepath
-    , hspec
-    , megaparsec
-    , monad-logger
-    , mtl
-    , process
+    , bytestring ==0.10.12.0
+    , cabal-install-parsers ==0.3.0.1
+    , containers ==0.6.2.1
+    , directory ==1.3.6.0
+    , file-embed ==0.0.13.0
+    , file-path-th ==0.1.0.0
+    , filepath ==1.4.2.1
+    , hspec ==2.7.8
+    , megaparsec ==9.0.1
+    , monad-logger ==0.3.36
+    , mtl ==2.2.2
+    , process ==1.6.9.0
     , prune-juice
-    , text
-    , yaml
+    , text ==1.2.4.1
+    , yaml ==0.11.5.0
   default-language: Haskell2010


### PR DESCRIPTION
Setting version constraints allows this package to be `cabal install`ed. For example, try `cabal install prune-juice`. Right now, this command fails because it selects the wrong versions of `aeson` and `Cabal`. To get it to succeed, you need to run `cabal install prune-juice --constraint='aeson < 2.0.0.0' --constraint='Cabal < 3.6.0.0'` even though the project ostensibly has locked every version of its dependencies.

I looked up these specific versions from the versions provided by Stack resolver `lts-17.5`. 

The main downside here is that every time the Stack resolver changes, these versions will need to be updated. I've made a feature request to `hpack` to automate this process at https://github.com/sol/hpack/issues/454.