### PR TITLE
Parse re-exports in ghc-pkg exposed-modules

### DIFF
--- a/app/main.hs
+++ b/app/main.hs
@@ -1,3 +1,5 @@
+module Main (main) where
+
 import Prelude
 
 import Control.Applicative ((<|>), many, optional)

--- a/src/Data/Prune/Cabal.hs
+++ b/src/Data/Prune/Cabal.hs
@@ -1,4 +1,9 @@
-module Data.Prune.Cabal where
+module Data.Prune.Cabal (
+  findCabalFiles,
+  parseCabalFile,
+  parseCabalFiles,
+  parseCabalProjectFile,
+) where
 
 import Prelude
 

--- a/src/Data/Prune/Dependency.hs
+++ b/src/Data/Prune/Dependency.hs
@@ -1,5 +1,5 @@
 -- |Load dependencies for a project using `ghc-pkg`.
-module Data.Prune.Dependency where
+module Data.Prune.Dependency (getDependencyByModule, parsePkg) where
 
 import Prelude hiding (words)
 

--- a/src/Data/Prune/Dependency.hs
+++ b/src/Data/Prune/Dependency.hs
@@ -3,6 +3,7 @@ module Data.Prune.Dependency (getDependencyByModule, parsePkg) where
 
 import Prelude hiding (words)
 
+import Cabal.Config (cfgStoreDir, readConfig)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.Logger (MonadLogger, logError)
 import Data.Functor.Identity (runIdentity)
@@ -12,6 +13,9 @@ import Data.Maybe (catMaybes)
 import Data.Set (Set)
 import Data.Text (Text, pack, splitOn, strip, unpack, words)
 import Data.Text.Encoding (encodeUtf8, decodeUtf8)
+import Distribution.InstalledPackageInfo (InstalledPackageInfo(..), parseInstalledPackageInfo, ExposedModule (..))
+import Distribution.ModuleName (components)
+import Distribution.Package (PackageIdentifier(..), unPackageName)
 import System.Directory (doesDirectoryExist)
 import System.FilePath.Posix ((</>))
 import System.Process (readProcess)
@@ -20,10 +24,6 @@ import qualified Data.Set as Set
 
 import qualified Data.Prune.Types as T
 
-import Cabal.Config (cfgStoreDir, readConfig)
-import Distribution.InstalledPackageInfo (InstalledPackageInfo(..), parseInstalledPackageInfo, ExposedModule (..))
-import Distribution.ModuleName (components)
-import Distribution.Package (PackageIdentifier(..), unPackageName)
 
 parsePkg :: (MonadLogger m) => Text -> m (Maybe (T.DependencyName, Set T.ModuleName))
 parsePkg s = case parseInstalledPackageInfo input of

--- a/src/Data/Prune/Dependency.hs
+++ b/src/Data/Prune/Dependency.hs
@@ -30,11 +30,13 @@ parsePkg s = case parseInstalledPackageInfo input of
   Left err -> do
     $logError $ "Failed to parse package due to " <> pack (show err) <> "; original input " <> decodeUtf8 input
     pure Nothing
-  Right (_, InstalledPackageInfo{sourcePackageId = PackageIdentifier{pkgName}, exposedModules}) ->
+  Right (_, InstalledPackageInfo{sourcePackageId = PackageIdentifier{pkgName}, exposedModules})
+        | not $ null $ unPackageName pkgName ->
     pure $ Just (
       T.DependencyName $ pack $ unPackageName pkgName,
       Set.fromList $ T.ModuleName . pack . intercalate "." . components . exposedName <$> exposedModules
     )
+  Right _ -> pure Nothing
   where
     input = encodeUtf8 $ strip s
 

--- a/src/Data/Prune/File.hs
+++ b/src/Data/Prune/File.hs
@@ -1,4 +1,4 @@
-module Data.Prune.File where
+module Data.Prune.File (listFilesRecursive) where
 
 import Prelude
 

--- a/src/Data/Prune/ImportParser.hs
+++ b/src/Data/Prune/ImportParser.hs
@@ -1,5 +1,5 @@
 -- |Utilities for parsing imports from Haskell source files.
-module Data.Prune.ImportParser where
+module Data.Prune.ImportParser (getCompilableUsedDependencies, oneImport) where
 
 import Prelude
 
@@ -16,7 +16,7 @@ import Data.Text (pack)
 import Data.Traversable (for)
 import Data.Void (Void)
 import Text.Megaparsec (Parsec, between, oneOf, parse)
-import Text.Megaparsec.Char (alphaNumChar, char, space, string, symbolChar, upperChar)
+import Text.Megaparsec.Char (alphaNumChar, char, space, string, symbolChar)
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 
@@ -45,9 +45,6 @@ symbol' = operator <|> some (alphaNumChar <|> oneOf ("._'" :: String))
 symbol :: Parser String
 symbol = padded symbol'
 
-moduleName :: Parser String
-moduleName = padded $ fmap mconcat $ some $ fmap mconcat $ sequence [(:[]) <$> upperChar, symbol']
-
 pkgName :: Parser String
 pkgName = some (alphaNumChar <|> char '-')
 
@@ -58,33 +55,11 @@ oneImport = void (string "import") *> space
   *> optional (void (padded (quoted pkgName)) *> space)
   *> (T.ModuleName . pack <$> (symbol <* space))
 
-dependencyName :: Parser T.DependencyName
-dependencyName = void (string "name:") *> space
-  *> (T.DependencyName . pack <$> pkgName)
-
-exposedModules :: Parser (Set T.ModuleName)
-exposedModules = void (string "exposed-modules:") *> space
-  *> (Set.fromList <$> some (T.ModuleName . pack <$> moduleName))
-
 -- |Parse a Haskell source file's imports.
 parseFileImports :: FilePath -> IO (Either String (Set T.ModuleName))
 parseFileImports fp = do
   left show . fmap Set.fromList . traverse (parse oneImport fp) . filter (isPrefixOf "import ") . lines
     <$> readFile fp
-
--- |Parse name from the `ghc-pkg` field description.
-parseDependencyName :: String -> Either String (Maybe T.DependencyName)
-parseDependencyName input =
-  if null input
-    then Right Nothing
-    else left show . fmap Just . parse dependencyName "" $ input
-
--- |Parse exposed modules from the `ghc-pkg` field description.
-parseExposedModules :: String -> Either String (Set T.ModuleName)
-parseExposedModules input =
-  if null input
-    then pure mempty
-    else left show $ parse exposedModules "" input
 
 -- |Get the dependencies used by a list of modules imported by a Haskell source file.
 getUsedDependencies :: Map T.ModuleName (Set T.DependencyName) -> Set T.ModuleName -> Set T.DependencyName

--- a/src/Data/Prune/Stack.hs
+++ b/src/Data/Prune/Stack.hs
@@ -1,4 +1,4 @@
-module Data.Prune.Stack where
+module Data.Prune.Stack (parseStackYaml) where
 
 import Prelude
 

--- a/src/Data/Prune/Types.hs
+++ b/src/Data/Prune/Types.hs
@@ -1,5 +1,21 @@
 -- |Types for pruning.
-module Data.Prune.Types where
+module Data.Prune.Types (
+  DependencyName(..),
+  ModuleName(..),
+  Compilable(..),
+  CompilableName(..),
+  CompilableType(..),
+  Package(..),
+  BuildSystem(..),
+  parseBuildSystem,
+  allBuildSystems,
+  StackYaml(..),
+  Verbosity(..),
+  parseVerbosity,
+  allVerbosities,
+  headMay,
+  lastMay,
+) where
 
 import Prelude
 

--- a/test/Data/Prune/CabalSpec.hs
+++ b/test/Data/Prune/CabalSpec.hs
@@ -1,4 +1,4 @@
-module Data.Prune.CabalSpec where
+module Data.Prune.CabalSpec (spec) where
 
 import Prelude
 

--- a/test/Data/Prune/DependencySpec.hs
+++ b/test/Data/Prune/DependencySpec.hs
@@ -1,4 +1,4 @@
-module Data.Prune.DependencySpec where
+module Data.Prune.DependencySpec (spec) where
 
 import Prelude
 

--- a/test/Data/Prune/ImportParserSpec.hs
+++ b/test/Data/Prune/ImportParserSpec.hs
@@ -1,10 +1,9 @@
-module Data.Prune.ImportParserSpec where
+module Data.Prune.ImportParserSpec (spec) where
 
 import Prelude
 
 import Test.Hspec (Spec, describe, it, shouldBe)
 import Text.Megaparsec (parse)
-import qualified Data.Set as Set
 
 import qualified Data.Prune.Types as T
 
@@ -30,23 +29,3 @@ spec = describe "Data.Prune.ImportParser" $ do
 
   it "should parse something complicated" $ do
     parse oneImport "" "import   qualified   \"foobar\"   Foo.Bar   as   Baz (foo, bar) " `shouldBe` Right (T.ModuleName "Foo.Bar")
-
-  it "should parse dependency name" $ do
-    parse dependencyName "" "name: foo-bar" `shouldBe` Right (T.DependencyName "foo-bar")
-
-  it "should parse exposed modules - single line" $ do
-    parse exposedModules "" "exposed-modules: Hpack Hpack.Config Hpack.Render Hpack.Yaml"
-      `shouldBe` Right (Set.fromList [T.ModuleName "Hpack", T.ModuleName "Hpack.Config", T.ModuleName "Hpack.Render", T.ModuleName "Hpack.Yaml"])
-
-  it "should parse exposed modules - multiline" $ do
-    parse exposedModules "" "exposed-modules: Text.Megaparsec Text.Megaparsec.Byte\n\
-                                              \Text.Megaparsec.Byte.Lexer Text.Megaparsec.Char\n\
-                                              \Text.Megaparsec.Char.Lexer Text.Megaparsec.Debug\n\
-                                              \Text.Megaparsec.Error Text.Megaparsec.Error.Builder\n\
-                                              \Text.Megaparsec.Internal Text.Megaparsec.Pos Text.Megaparsec.Stream"
-      `shouldBe` Right ( Set.fromList
-        [ T.ModuleName "Text.Megaparsec", T.ModuleName "Text.Megaparsec.Byte"
-        , T.ModuleName "Text.Megaparsec.Byte.Lexer", T.ModuleName "Text.Megaparsec.Char"
-        , T.ModuleName "Text.Megaparsec.Char.Lexer", T.ModuleName "Text.Megaparsec.Debug"
-        , T.ModuleName "Text.Megaparsec.Error", T.ModuleName "Text.Megaparsec.Error.Builder"
-        , T.ModuleName "Text.Megaparsec.Internal", T.ModuleName "Text.Megaparsec.Pos", T.ModuleName "Text.Megaparsec.Stream" ] )


### PR DESCRIPTION
Resolves #9.

I found the native `ghc-pkg` parser for `InstalledPackageInfo` from [`ghc-pkg`'s source code](https://gitlab.haskell.org/ghc/ghc/-/blob/master/utils/ghc-pkg/Main.hs#L1192), and used that instead of a hand-rolled parser.

It looks like the breakage in #9 is indeed caused by re-exports. When an [`ExposedModule`](https://hackage.haskell.org/package/Cabal-3.4.1.0/docs/Distribution-InstalledPackageInfo.html#t:ExposedModule) has a re-export, it appears to use this alternate syntax. It looks like [first-class re-exports](https://hackage.haskell.org/package/Cabal-3.4.1.0/docs/Distribution-Backpack.html#t:OpenModule) were introduced for Backpack, to describe "open modules" that where many modules can provide a specific signature.