### PR TITLE
Fix sublib parser

### DIFF
--- a/src/Data/Prune/Dependency.hs
+++ b/src/Data/Prune/Dependency.hs
@@ -36,6 +36,9 @@ parsePkg s = case parseInstalledPackageInfo (encodeUtf8 s) of
     $logError $ "Failed to parse package due to " <> pack (show err) <> "; original input " <> s
     pure Nothing
   Right (_, installedPackageInfo) ->
+    -- https://hackage.haskell.org/package/Cabal-3.8.1.0/docs/Distribution-Simple-LocalBuildInfo.html#t:LibraryName
+    -- In case this is a sublib we want the sublib name not the package name.
+    -- We coul also fech the main lib name, but the package name is probably fine
     let packageName =
           case InstalledPackageInfo.sourceLibName installedPackageInfo of
             LibraryName.LMainLibName -> PackageName.unPackageName . PackageId.pkgName . InstalledPackageInfo.sourcePackageId $ installedPackageInfo

--- a/src/Data/Prune/Section/Parser.hs
+++ b/src/Data/Prune/Section/Parser.hs
@@ -9,7 +9,7 @@ import Control.Monad (void)
 import Data.List (isSuffixOf)
 import Data.Text (pack, unpack)
 import Data.Void (Void)
-import Text.Megaparsec (Parsec, many, noneOf, parse, some, try, errorBundlePretty)
+import Text.Megaparsec (Parsec, many, noneOf, parse, some, try, errorBundlePretty, optional)
 import Text.Megaparsec.Char (alphaNumChar, char, eol, hspace, hspace1, string)
 
 import qualified Data.Prune.Section.Types as T
@@ -58,9 +58,9 @@ section :: Parser T.Section
 section =
   let lib = do
         void $ string "library"
-        hspace
+        mname <- optional (hspace1 >> targetName)
         void eol
-        T.TargetSection T.CompilableTypeLibrary Nothing <$> nestedSections
+        T.TargetSection T.CompilableTypeLibrary mname <$> nestedSections
       target typ typName = do
         void $ string typName
         hspace1
@@ -73,12 +73,11 @@ section =
         hspace1
         name <- T.CommonName . pack <$> restOfLine
         T.CommonSection name <$> nestedSections
-      sublib = target T.CompilableTypeLibrary "library"
       exe = target T.CompilableTypeExecutable "executable"
       test = target T.CompilableTypeTest "test-suite"
       bench = target T.CompilableTypeBenchmark "benchmark"
       other = T.OtherSection <$> indentedLines 0
-  in lib <|> sublib <|> exe <|> test <|> bench <|> common <|> other
+  in lib <|> exe <|> test <|> bench <|> common <|> other
 
 sections :: Parser [T.Section]
 sections = some section

--- a/src/Data/Prune/Section/Parser.hs
+++ b/src/Data/Prune/Section/Parser.hs
@@ -9,7 +9,7 @@ import Control.Monad (void)
 import Data.List (isSuffixOf)
 import Data.Text (pack, unpack)
 import Data.Void (Void)
-import Text.Megaparsec (Parsec, many, noneOf, parse, some, try)
+import Text.Megaparsec (Parsec, many, noneOf, parse, some, try, errorBundlePretty)
 import Text.Megaparsec.Char (alphaNumChar, char, eol, hspace, hspace1, string)
 
 import qualified Data.Prune.Section.Types as T
@@ -85,7 +85,7 @@ sections = some section
 
 -- |Parse using 'sections'.
 parseCabalSections :: String -> Either String [T.Section]
-parseCabalSections = left show . parse sections ""
+parseCabalSections = left errorBundlePretty . parse sections ""
 
 -- |Render sections. @parseCabalSections . renderCabalSections@ should be equivalent to @Right@.
 renderCabalSections :: [T.Section] -> String

--- a/test/Data/Prune/Section/ParserSpec.hs
+++ b/test/Data/Prune/Section/ParserSpec.hs
@@ -19,14 +19,15 @@ buildDependsNestedSection = T.BuildDependsNestedSection 2 ["", "    , base <5.0"
 importNestedSection = T.ImportNestedSection 2 [" foo, bar"]
 otherNestedSection = T.OtherNestedSection 2 ["default-language: Haskell2010"]
 
-librarySection, executableSection, commonSection, otherSection :: T.Section
+librarySection, sublibrarySection, executableSection, commonSection, otherSection :: T.Section
 librarySection = T.TargetSection T.CompilableTypeLibrary Nothing [importNestedSection, buildDependsNestedSection, otherNestedSection]
+sublibrarySection = T.TargetSection T.CompilableTypeLibrary (Just (T.CompilableName "baz")) [importNestedSection, buildDependsNestedSection, otherNestedSection]
 executableSection = T.TargetSection T.CompilableTypeExecutable (Just (T.CompilableName "prune-juice")) [buildDependsNestedSection, otherNestedSection]
 commonSection = T.CommonSection (T.CommonName "foo") [buildDependsNestedSection, otherNestedSection]
 otherSection = T.OtherSection ["name: prune-juice"]
 
 buildDependsNestedExample, importNestedExample, otherNestedExample
-  , libraryExample, executableExample, commonExample, otherExample :: String
+  , libraryExample, sublibraryExample, executableExample, commonExample, otherExample :: String
 buildDependsNestedExample = unlines
   [ "  build-depends:"
   , "    , base <5.0"
@@ -58,6 +59,13 @@ commonExample = unlines
   ]
 otherExample = unlines
   [ "name: prune-juice"
+  ]
+sublibraryExample = unlines
+  [ "library baz"
+  , "  import: foo, bar"
+  , "  build-depends:"
+  , "    , base <5.0"
+  , "  default-language: Haskell2010"
   ]
 
 spec :: Spec
@@ -92,6 +100,9 @@ spec = describe "Data.Prune.Section.Parser" $ do
 
   it "should parse a library section" $
     parse section "" libraryExample `shouldBe` Right librarySection
+
+  it "should parse a sublibrary section" $
+    parse section "" sublibraryExample `shouldBe` Right sublibrarySection
 
   it "should parse an executable section" $
     parse section "" executableExample `shouldBe` Right executableSection

--- a/test/fixtures/sublib-pkg.txt
+++ b/test/fixtures/sublib-pkg.txt
@@ -1,0 +1,67 @@
+name:                 prune-juice-fixture
+version:              0.1.0.0
+visibility:           public
+id:                   prune-juice-fixture-0.1.0.0-inplace
+key:                  prune-juice-fixture-0.1.0.0-inplace
+maintainer:           dbalseiro@stackbuilders.com
+author:               Diego Balseiro
+abi:                  inplace
+exposed:              True
+exposed-modules:      MyLib
+import-dirs:
+    /home/dbalseiro/code/prune-juice-fixture/dist-newstyle/build/x86_64-linux/ghc-8.10.7/prune-juice-fixture-0.1.0.0/build
+
+library-dirs:
+    /home/dbalseiro/code/prune-juice-fixture/dist-newstyle/build/x86_64-linux/ghc-8.10.7/prune-juice-fixture-0.1.0.0/build
+
+dynamic-library-dirs:
+    /home/dbalseiro/code/prune-juice-fixture/dist-newstyle/build/x86_64-linux/ghc-8.10.7/prune-juice-fixture-0.1.0.0/build
+
+data-dir:             /home/dbalseiro/code/prune-juice-fixture/.
+hs-libraries:         HSprune-juice-fixture-0.1.0.0-inplace
+depends:
+    base-4.14.3.0
+    prune-juice-fixture-0.1.0.0-inplace-prune-juice-fixture-common
+
+haddock-interfaces:
+    /home/dbalseiro/code/prune-juice-fixture/dist-newstyle/build/x86_64-linux/ghc-8.10.7/prune-juice-fixture-0.1.0.0/doc/html/prune-juice-fixture/prune-juice-fixture.haddock
+
+haddock-html:
+    /home/dbalseiro/code/prune-juice-fixture/dist-newstyle/build/x86_64-linux/ghc-8.10.7/prune-juice-fixture-0.1.0.0/doc/html/prune-juice-fixture
+pkgroot: "/home/dbalseiro/code/prune-juice-fixture/dist-newstyle/packagedb"
+---
+name:                 z-prune-juice-fixture-z-prune-juice-fixture-common
+version:              0.1.0.0
+package-name:         prune-juice-fixture
+lib-name:             prune-juice-fixture-common
+id:
+    prune-juice-fixture-0.1.0.0-inplace-prune-juice-fixture-common
+
+key:
+    prune-juice-fixture-0.1.0.0-inplace-prune-juice-fixture-common
+
+maintainer:           dbalseiro@stackbuilders.com
+author:               Diego Balseiro
+abi:                  inplace
+exposed-modules:      Common
+import-dirs:
+    /home/dbalseiro/code/prune-juice-fixture/dist-newstyle/build/x86_64-linux/ghc-8.10.7/prune-juice-fixture-0.1.0.0/l/prune-juice-fixture-common/build/prune-juice-fixture-common
+
+library-dirs:
+    /home/dbalseiro/code/prune-juice-fixture/dist-newstyle/build/x86_64-linux/ghc-8.10.7/prune-juice-fixture-0.1.0.0/l/prune-juice-fixture-common/build/prune-juice-fixture-common
+
+dynamic-library-dirs:
+    /home/dbalseiro/code/prune-juice-fixture/dist-newstyle/build/x86_64-linux/ghc-8.10.7/prune-juice-fixture-0.1.0.0/l/prune-juice-fixture-common/build/prune-juice-fixture-common
+
+data-dir:             /home/dbalseiro/code/prune-juice-fixture/.
+hs-libraries:
+    HSprune-juice-fixture-0.1.0.0-inplace-prune-juice-fixture-common
+
+depends:              base-4.14.3.0
+haddock-interfaces:
+    /home/dbalseiro/code/prune-juice-fixture/dist-newstyle/build/x86_64-linux/ghc-8.10.7/prune-juice-fixture-0.1.0.0/l/prune-juice-fixture-common/doc/html/prune-juice-fixture/prune-juice-fixture.haddock
+
+haddock-html:
+    /home/dbalseiro/code/prune-juice-fixture/dist-newstyle/build/x86_64-linux/ghc-8.10.7/prune-juice-fixture-0.1.0.0/l/prune-juice-fixture-common/doc/html/prune-juice-fixture
+pkgroot: "/home/dbalseiro/code/prune-juice-fixture/dist-newstyle/packagedb"
+


### PR DESCRIPTION
Hey @dfithian thanks for this tool :smile: I use it quite often.

I had trouble working with projects using [sub libraries](https://cabal.readthedocs.io/en/stable/cabal-package.html#sublibs). I think I fixed the issue and thought about sending the fix upstream.

I made [this repo](https://github.com/dbalseiro/prune-juice-fixture) to replicate the issue.

The error I got is the following:
```
$ prune-juice
Failed to parse cabal sections for ./prune-juice-fixture.cabal l due to ParseErrorBundle {bundleErrors = TrivialError 854 (Just (...
```

and a long error message. I first added a more legible error message using [megaparsec pretty print](https://hackage.haskell.org/package/megaparsec-9.2.2/docs/Text-Megaparsec-Error.html#v:parseErrorPretty), so now you have this:
```
$ prune-juice
Failed to parse cabal sections for ./prune-juice-fixture.cabal due to 39:9:
   |
39 | library prune-juice-fixture-common
   |         ^^
unexpected "pr"
expecting end of line or white space

Some unused base dependencies for package prune-juice-fixture
  prune-juice-fixture-common
```

That line *is* valid, but the parser didn't identify a sublibrary correctly. Basically, it tried
to parse the main library instead a sub-library. So I [fixed the parser](https://github.com/dbalseiro/prune-juice/blob/294559eab469fd008260c8a57cbcc05b13e2356c/src/Data/Prune/Section/Parser.hs#L61). Now it can parse sublibraries in the cabal file

Also, as you can see, the dependencies parser incorrectly marked the sub-lib as unused, even though *it is* being used. This happened because it was giving the same name (package name) to both
the main library and the sub library. So I [fixed that too](https://github.com/dbalseiro/prune-juice/blob/86edfe552dfeeb3eac3f71a2e25754fe490fa239/src/Data/Prune/Dependency.hs#L39-L42).

This PR should also fix issue #22 

If you have any comments, please let me know. Thanks!

