### PR TITLE
Update dependency bounds

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,2 +1,0 @@
-packages: ./*.cabal
-constraints: cabal-install-parsers == 0.4

--- a/prune-juice.cabal
+++ b/prune-juice.cabal
@@ -68,7 +68,7 @@ common options
       TypeOperators
       ViewPatterns
   build-depends:
-      Cabal >= 3.2 && < 3.7
+      Cabal >= 3.2 && < 3.9
     , aeson
     , base
     , bytestring

--- a/prune-juice.cabal
+++ b/prune-juice.cabal
@@ -82,7 +82,7 @@ common options
     , process >= 1.6.13.2 && < 1.7
     , regex-compat >= 0.95.2.1 && < 0.96
     , text >= 1.2.4.1 && < 1.3
-    , text-ansi >= 0.1.1 && < 0.2
+    , text-ansi >= 0.2 && < 0.3
     , yaml >= 0.11.6.0 && < 0.12
   default-language: Haskell2010
 

--- a/prune-juice.cabal
+++ b/prune-juice.cabal
@@ -68,22 +68,22 @@ common options
       TypeOperators
       ViewPatterns
   build-depends:
-      Cabal >= 3.2.1.0 && < 3.3
-    , aeson >= 1.5.6.0 && < 1.6
-    , base < 5.0
-    , bytestring >= 0.10.12.0 && < 0.11
-    , cabal-install-parsers >= 0.4 && < 0.5
-    , containers >= 0.6.5.1 && < 0.7
-    , directory >= 1.3.6.0 && < 1.4
-    , filepath >= 1.4.2.1 && < 1.5
-    , megaparsec >= 9.0.1 && < 9.1
-    , monad-logger >= 0.3.36 && < 0.4
-    , mtl >= 2.2.2 && < 2.3
-    , process >= 1.6.13.2 && < 1.7
-    , regex-compat >= 0.95.2.1 && < 0.96
-    , text >= 1.2.4.1 && < 1.3
+      Cabal >= 3.2 && < 3.7
+    , aeson
+    , base
+    , bytestring
+    , cabal-install-parsers
+    , containers
+    , directory
+    , filepath
+    , megaparsec
+    , monad-logger
+    , mtl
+    , process
+    , regex-compat
+    , text
     , text-ansi >= 0.2 && < 0.3
-    , yaml >= 0.11.6.0 && < 0.12
+    , yaml
   default-language: Haskell2010
 
 library

--- a/src/Data/Prune/Cabal.hs
+++ b/src/Data/Prune/Cabal.hs
@@ -13,7 +13,11 @@ import Data.Set (Set)
 import Data.Text (Text, pack)
 import Data.Traversable (for)
 import Distribution.ModuleName (ModuleName)
+#if MIN_VERSION_Cabal(3,8,0)
+import Distribution.Simple.PackageDescription (readGenericPackageDescription)
+#else
 import Distribution.PackageDescription.Parsec (readGenericPackageDescription)
+#endif
 import Distribution.Types.Benchmark (Benchmark)
 import Distribution.Types.BuildInfo (BuildInfo)
 import Distribution.Types.CondTree (CondTree)

--- a/src/Data/Prune/Confirm.hs
+++ b/src/Data/Prune/Confirm.hs
@@ -5,7 +5,7 @@ import Prelude
 
 import Data.Char (toLower)
 import Data.Text (pack, unpack)
-import qualified Data.Text.ANSI as Text.ANSI
+import qualified Text.ANSI
 
 err, warn, bold :: String -> String
 err = unpack . Text.ANSI.bold . Text.ANSI.red . pack


### PR DESCRIPTION
I wanted to use `prune-juice` from Nixpkgs, but it fails to compile. In particular because it's using an older version of `text-ansi`, but more generally because the dependency bounds are so strict (I had to drop many bounds to get `prune-juice` to compile while I was developing this change).

I think removing strict bounds will keep this package compiling for longer with less maintenance.